### PR TITLE
Update OneAPI base toolkit to Latest Version for Windows SYCL Backend

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1173,7 +1173,7 @@ jobs:
         shell: bash
 
     env:
-      WINDOWS_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/b380d914-366b-4b77-a74a-05e3c38b3514/intel-oneapi-base-toolkit-2025.0.0.882_offline.exe
+      WINDOWS_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/487fd8c3-a3d8-4c22-a903-f8d54c2c57be/intel-oneapi-base-toolkit-2025.1.0.650_offline.exe
       WINDOWS_DPCPP_MKL: intel.oneapi.win.cpp-dpcpp-common:intel.oneapi.win.mkl.devel:intel.oneapi.win.dnnl:intel.oneapi.win.tbb.devel
       ONEAPI_ROOT: "C:/Program Files (x86)/Intel/oneAPI"
     steps:


### PR DESCRIPTION
Hello,

I have created a pull request for the Windows SYCL backend. The version of the OneAPI base toolkit used in the Windows build was 2025.0.0, which is outdated, so I have updated it to the latest version (2025.1.0).

I conducted a performance comparison between the SYCL version of llama.cpp in this repository and the version built in the [ipex-llm repository](https://github.com/intel/ipex-llm/releases/tag/v2.2.0) using the following URL. The results showed that the llama.cpp version in this repository is slower. (The article is in Japanese.)

[Performance Comparison Article](https://qiita.com/kotauchisunsun/items/ebfe8dde6146afd121c6)

Based on these findings, I suspect that the outdated OneAPI base toolkit version is the cause of the slow performance of llama.cpp. Therefore, I have created this pull request.

I attempted to create a pull request on my own fork, but I was unable to build it due to Intel's licensing restrictions. Since my repository does not have the required license files, the build could not proceed. However, I believe that the build server for llama.cpp has the necessary license files, so it should function correctly there

[Build Attempt Log](https://github.com/kotauchisunsun/llama.cpp/actions/runs/14532679328/job/40775260004)

Could you please review and merge this pull request?
If there are any additional necessary actions, please let me know.